### PR TITLE
console: matches changes

### DIFF
--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -278,17 +278,8 @@ namespace game_console
 			if (matches.size() > 24)
 			{
 				draw_hint_box(1, dvars::con_inputHintBoxColor->current.vector);
-				draw_hint_text(0, utils::string::va("%i matches (too many to show here. Press shift+tilde to open full console)", matches.size()),
+				draw_hint_text(0, utils::string::va("%i matches (too many to show here. press shift+tilde to open full console, press tab to print all matches)", matches.size()),
 					dvars::con_inputDvarMatchColor->current.vector);
-
-				if (GetAsyncKeyState(VK_TAB) & 1)
-				{
-					console::info("]%s\n", con.buffer);
-					for (size_t i = 0; i < matches.size(); i++)
-					{
-						console::info("\t%s\n", matches[i].data());
-					}
-				}
 			}
 			else if (matches.size() == 1)
 			{
@@ -720,6 +711,15 @@ namespace game_console
 					history_index = -1;
 
 					clear();
+				}
+
+				if (key == game::keyNum_t::K_TAB && std::strlen(con.buffer) >= 2 && matches.size() > 24)
+				{
+					console::info("]%s\n", con.buffer);
+					for (const auto& match : matches)
+					{
+						console::info("\t%s\n", match.data());
+					}
 				}
 			}
 		}

--- a/src/client/component/game_console.cpp
+++ b/src/client/component/game_console.cpp
@@ -278,10 +278,10 @@ namespace game_console
 			if (matches.size() > 24)
 			{
 				draw_hint_box(1, dvars::con_inputHintBoxColor->current.vector);
-				draw_hint_text(0, utils::string::va("%i matches (too many to show here). Press SHIFT + TAB to show more", matches.size()),
+				draw_hint_text(0, utils::string::va("%i matches (too many to show here. Press shift+tilde to open full console)", matches.size()),
 					dvars::con_inputDvarMatchColor->current.vector);
 
-				if (game::playerKeys[0].keys[game::keyNum_t::K_SHIFT].down && game::playerKeys[0].keys[game::keyNum_t::K_TAB].down)
+				if (GetAsyncKeyState(VK_TAB) & 1)
 				{
 					console::info("]%s\n", con.buffer);
 					for (size_t i = 0; i < matches.size(); i++)


### PR DESCRIPTION
changed keybinds from shift+tab to just **tab** so it doesn't interrupt with steam overlay

also, it may closes #16 