### PR TITLE
feat: Add windows 11 style borders to splash screen

### DIFF
--- a/src/client/component/splash.cpp
+++ b/src/client/component/splash.cpp
@@ -128,6 +128,8 @@ namespace splash
 							SetWindowPos(this->window_, nullptr, rect.left, rect.top, rect.right - rect.left,
 								rect.bottom - rect.top, SWP_NOZORDER);
 
+							SetWindowRgn(this->window_, CreateRoundRectRgn(0, 0, rect.right - rect.left, rect.bottom - rect.top, 15, 15), TRUE);
+
 							ShowWindow(this->window_, SW_SHOW);
 							UpdateWindow(this->window_);
 						}


### PR DESCRIPTION
Adds windows 11 styled borders to splash screen.

Based on boiii - https://github.com/momo5502/boiii/blob/main/src/client/component/splash.cpp